### PR TITLE
feat(capture): add automatic capture FPS

### DIFF
--- a/MetalDuck/App/AppCoordinator.swift
+++ b/MetalDuck/App/AppCoordinator.swift
@@ -38,6 +38,7 @@ class AppCoordinator {
     private var sourceFrameCount = 0
     private var currentSourceFPS: Double = 0
     private var lastFrameTimestamp: CMTime?
+    private var frameRateEstimator = FrameRateEstimator(initialFrameRate: 60)
 
     init() {
         setupComponents()
@@ -93,6 +94,7 @@ class AppCoordinator {
         if #available(macOS 12.3, *) {
             // Match capture resolution to window size before starting capture
             await matchCaptureResolutionToWindow()
+            prepareCaptureFrameRateForStart()
 
             captureManager = ScreenCaptureManager(settings: captureSettings)
 
@@ -149,11 +151,13 @@ class AppCoordinator {
 
         overlayManager?.close()
         lastFrameTimestamp = nil
+        resetAutoFrameRateEstimator()
     }
 
     private func processFrame(_ frame: CapturedFrame) async {
         guard let overlay = overlayManager else { return }
         sourceFrameCount += 1
+        await updateAutoFrameRateIfNeeded(for: frame)
 
         let currentPTS = frame.presentationTimestamp
         let prevPTS = lastFrameTimestamp ?? currentPTS
@@ -273,6 +277,9 @@ class AppCoordinator {
             overlayManager?.updateDebugInfo(
                 fps: fps,
                 sourceFPS: currentSourceFPS,
+                effectiveCaptureFPS: captureSettings.frameRate,
+                autoCaptureFPS: captureSettings.autoFrameRateEnabled,
+                estimatedGameFPS: frameRateEstimator.estimatedFrameRate,
                 status: appState.processingStatus,
                 captureRes: captureSettings.captureResolution,
                 processingRes: processingRes,
@@ -309,6 +316,15 @@ class AppCoordinator {
         videoToolboxUpscaler?.updateSettings(newSettings)
     }
 
+    func updateCaptureSettings(_ newSettings: CaptureSettings) {
+        let autoFrameRateChanged = captureSettings.autoFrameRateEnabled != newSettings.autoFrameRateEnabled
+        captureSettings = newSettings
+
+        if autoFrameRateChanged {
+            resetAutoFrameRateEstimator()
+        }
+    }
+
     // MARK: - Picker
 
     @available(macOS 12.3, *)
@@ -332,6 +348,8 @@ class AppCoordinator {
         guard let overlay = overlayManager else { return }
 
         do {
+            prepareCaptureFrameRateForStart()
+            captureManager = ScreenCaptureManager(settings: captureSettings)
             let stream = try await captureManager!.startCapture()
             // Apply the picked filter to the new session
             await captureManager?.applyPickerFilter(filter)
@@ -357,6 +375,42 @@ class AppCoordinator {
             }
         } catch {
             appState.setError("Failed to start capture: \(error.localizedDescription)")
+        }
+    }
+
+    private func prepareCaptureFrameRateForStart() {
+        if captureSettings.autoFrameRateEnabled {
+            captureSettings.frameRate = CaptureSettings.autoFrameRateSamplingCeiling
+        }
+        resetAutoFrameRateEstimator()
+        videoToolboxUpscaler?.updateSourceFrameRate(captureSettings.frameRate)
+    }
+
+    private func resetAutoFrameRateEstimator() {
+        frameRateEstimator.reset(initialFrameRate: captureSettings.frameRate)
+    }
+
+    private func updateAutoFrameRateIfNeeded(for frame: CapturedFrame) async {
+        guard captureSettings.autoFrameRateEnabled else { return }
+
+        guard let recommendedFrameRate = frameRateEstimator.observe(
+            timestamp: frame.frameRateTimestamp,
+            changedAreaRatio: frame.changedAreaRatio
+        ) else {
+            return
+        }
+
+        guard recommendedFrameRate != captureSettings.frameRate else { return }
+
+        do {
+            try await captureManager?.updateFrameRate(recommendedFrameRate)
+            captureSettings.frameRate = recommendedFrameRate
+            videoToolboxUpscaler?.updateSourceFrameRate(recommendedFrameRate)
+            appState.processingStatus = "Auto capture FPS: \(recommendedFrameRate)"
+            print("   🎚️ Auto capture FPS adjusted to \(recommendedFrameRate)")
+        } catch {
+            appState.processingStatus = "Auto capture FPS update failed"
+            print("   ⚠️ Auto capture FPS update failed: \(error.localizedDescription)")
         }
     }
 }

--- a/MetalDuck/Capture/CaptureSession.swift
+++ b/MetalDuck/Capture/CaptureSession.swift
@@ -13,6 +13,7 @@ import CoreMedia
 @available(macOS 12.3, *)
 class CaptureSession {
     private var stream: SCStream?
+    private var streamConfig: SCStreamConfiguration?
     private var streamOutput: StreamOutput?
     private let settings: CaptureSettings
 
@@ -36,10 +37,11 @@ class CaptureSession {
 
         streamConfig.width = Int(settings.captureResolution.width)
         streamConfig.height = Int(settings.captureResolution.height)
-        streamConfig.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(settings.frameRate))
+        streamConfig.minimumFrameInterval = CaptureSettings.frameInterval(for: settings.frameRate)
         streamConfig.queueDepth = 5
         streamConfig.showsCursor = false
         streamConfig.capturesAudio = false
+        self.streamConfig = streamConfig
 
         let (frameStream, continuation) = AsyncThrowingStream.makeStream(of: CapturedFrame.self)
         self.continuation = continuation
@@ -59,6 +61,13 @@ class CaptureSession {
         return frameStream
     }
 
+    func updateFrameRate(_ frameRate: Int) async throws {
+        guard let stream, let streamConfig else { return }
+
+        streamConfig.minimumFrameInterval = CaptureSettings.frameInterval(for: frameRate)
+        try await stream.updateConfiguration(streamConfig)
+    }
+
     func updateContentFilter(_ filter: SCContentFilter) async {
         do {
             try await stream?.updateContentFilter(filter)
@@ -76,6 +85,7 @@ class CaptureSession {
         continuation?.finish()
         continuation = nil
         stream = nil
+        streamConfig = nil
         streamOutput = nil
     }
 

--- a/MetalDuck/Capture/CapturedFrame.swift
+++ b/MetalDuck/Capture/CapturedFrame.swift
@@ -8,6 +8,7 @@
 import Foundation
 import CoreMedia
 import CoreVideo
+import Darwin
 import IOSurface
 import ScreenCaptureKit
 
@@ -15,6 +16,8 @@ struct CapturedFrame: @unchecked Sendable {
     let surface: IOSurface
     let pixelBuffer: CVPixelBuffer
     let presentationTimestamp: CMTime
+    let frameRateTimestamp: TimeInterval
+    let changedAreaRatio: Double?
     let contentRect: CGRect
     let contentScale: CGFloat
     let scaleFactor: CGFloat
@@ -26,7 +29,7 @@ struct CapturedFrame: @unchecked Sendable {
 extension CapturedFrame {
     /// Creates a CapturedFrame from a CMSampleBuffer produced by SCStream.
     /// Returns nil if the frame status is not `.complete` or required data is missing.
-    static func from(sampleBuffer: CMSampleBuffer) -> CapturedFrame? {
+    nonisolated static func from(sampleBuffer: CMSampleBuffer) -> CapturedFrame? {
         guard sampleBuffer.isValid else { return nil }
 
         guard let attachmentsArray = CMSampleBufferGetSampleAttachmentsArray(
@@ -52,14 +55,88 @@ extension CapturedFrame {
         else { return nil }
 
         let timestamp = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+        let frameRateTimestamp = Self.frameRateTimestamp(
+            displayTime: attachments[.displayTime],
+            fallbackTimestamp: timestamp
+        )
+        let dirtyRects = Self.dirtyRects(from: attachments[.dirtyRects])
+        let changedAreaRatio = dirtyRects.map {
+            Self.changedAreaRatio(dirtyRects: $0, contentRect: contentRect, scaleFactor: scaleFactor)
+        }
 
         return CapturedFrame(
             surface: surface,
             pixelBuffer: pixelBuffer,
             presentationTimestamp: timestamp,
+            frameRateTimestamp: frameRateTimestamp,
+            changedAreaRatio: changedAreaRatio,
             contentRect: contentRect,
             contentScale: contentScale,
             scaleFactor: scaleFactor
         )
+    }
+
+    private nonisolated static func frameRateTimestamp(displayTime: Any?, fallbackTimestamp: CMTime) -> TimeInterval {
+        if let displayTime = displayTime as? UInt64 {
+            return seconds(fromMachAbsoluteTime: displayTime)
+        }
+
+        if let displayTime = displayTime as? NSNumber {
+            return seconds(fromMachAbsoluteTime: displayTime.uint64Value)
+        }
+
+        return CMTimeGetSeconds(fallbackTimestamp)
+    }
+
+    private nonisolated static func seconds(fromMachAbsoluteTime value: UInt64) -> TimeInterval {
+        var timebase = mach_timebase_info_data_t()
+        mach_timebase_info(&timebase)
+
+        guard timebase.denom != 0 else { return 0 }
+
+        let nanoseconds = Double(value) * Double(timebase.numer) / Double(timebase.denom)
+        return nanoseconds / 1_000_000_000
+    }
+
+    private nonisolated static func dirtyRects(from value: Any?) -> [CGRect]? {
+        if let rects = value as? [CGRect] {
+            return rects
+        }
+
+        if let values = value as? [NSValue] {
+            return values.map(\.rectValue)
+        }
+
+        if let array = value as? NSArray {
+            return array.compactMap { item -> CGRect? in
+                if let value = item as? NSValue {
+                    return value.rectValue
+                }
+                if let dictionary = item as? NSDictionary {
+                    return CGRect(dictionaryRepresentation: dictionary)
+                }
+                return nil
+            }
+        }
+
+        return nil
+    }
+
+    private nonisolated static func changedAreaRatio(
+        dirtyRects: [CGRect],
+        contentRect: CGRect,
+        scaleFactor: CGFloat
+    ) -> Double {
+        guard dirtyRects.isEmpty == false else { return 0 }
+
+        let contentWidth = max(1, contentRect.width * scaleFactor)
+        let contentHeight = max(1, contentRect.height * scaleFactor)
+        let contentArea = contentWidth * contentHeight
+
+        let changedArea = dirtyRects.reduce(CGFloat.zero) { total, rect in
+            total + max(0, rect.width) * max(0, rect.height)
+        }
+
+        return min(1, Double(changedArea / contentArea))
     }
 }

--- a/MetalDuck/Capture/ScreenCaptureManager.swift
+++ b/MetalDuck/Capture/ScreenCaptureManager.swift
@@ -46,6 +46,10 @@ class ScreenCaptureManager: NSObject {
         captureSession = nil
     }
 
+    func updateFrameRate(_ frameRate: Int) async throws {
+        try await captureSession?.updateFrameRate(frameRate)
+    }
+
     // MARK: - Content Picker
 
     func presentPicker() {

--- a/MetalDuck/Models/CaptureSettings.swift
+++ b/MetalDuck/Models/CaptureSettings.swift
@@ -5,6 +5,7 @@
 //  Created by Roberto Camargo on 07/11/25.
 //
 
+import CoreMedia
 import Foundation
 import ScreenCaptureKit
 
@@ -28,14 +29,23 @@ struct CaptureSettings: Codable {
     var targetDisplayID: CGDirectDisplayID?
     var captureResolution: CGSize
     var frameRate: Int
+    var autoFrameRateEnabled: Bool
     var useVirtualDisplay: Bool
     var selectedDynamicRangePreset: DynamicRangePreset?
+
+    static let autoFrameRateSamplingCeiling = 120
     
     init() {
         self.captureResolution = CGSize(width: 1920, height: 1080)
         self.frameRate = 60
+        self.autoFrameRateEnabled = false
         self.useVirtualDisplay = false
         self.selectedDynamicRangePreset = nil
+    }
+
+    static func frameInterval(for frameRate: Int) -> CMTime {
+        let clampedFrameRate = max(1, frameRate)
+        return CMTime(value: 1, timescale: CMTimeScale(clampedFrameRate))
     }
     
     @available(macOS 12.3, *)
@@ -66,4 +76,3 @@ struct CaptureSettings: Codable {
         return nil
     }
 }
-

--- a/MetalDuck/Models/FrameRateEstimator.swift
+++ b/MetalDuck/Models/FrameRateEstimator.swift
@@ -1,0 +1,138 @@
+//
+//  FrameRateEstimator.swift
+//  MetalDuck
+//
+//  Estimates a captured window's presented update rate from changed frame timing.
+//
+
+import Foundation
+
+struct FrameRateEstimator {
+    static let supportedFrameRates = [30, 40, 45, 50, 60, 72, 90, 100, 120]
+
+    private let windowDuration: TimeInterval
+    private let stabilityDuration: TimeInterval
+    private let cooldownDuration: TimeInterval
+    private let minimumChangedAreaRatio: Double
+    private var changedFrameTimestamps: [TimeInterval] = []
+    private var candidateFrameRate: Int?
+    private var candidateStartTime: TimeInterval?
+    private var lastRecommendationTime: TimeInterval?
+
+    private(set) var currentFrameRate: Int
+    private(set) var estimatedFrameRate: Int?
+
+    init(
+        initialFrameRate: Int = 60,
+        windowDuration: TimeInterval = 2.5,
+        stabilityDuration: TimeInterval = 2.0,
+        cooldownDuration: TimeInterval = 5.0,
+        minimumChangedAreaRatio: Double = 0.001
+    ) {
+        self.currentFrameRate = Self.quantizedFrameRate(for: Double(initialFrameRate))
+        self.windowDuration = windowDuration
+        self.stabilityDuration = stabilityDuration
+        self.cooldownDuration = cooldownDuration
+        self.minimumChangedAreaRatio = minimumChangedAreaRatio
+    }
+
+    mutating func reset(initialFrameRate: Int) {
+        changedFrameTimestamps.removeAll(keepingCapacity: true)
+        candidateFrameRate = nil
+        candidateStartTime = nil
+        lastRecommendationTime = nil
+        estimatedFrameRate = nil
+        currentFrameRate = Self.quantizedFrameRate(for: Double(initialFrameRate))
+    }
+
+    mutating func observe(timestamp: TimeInterval, changedAreaRatio: Double?) -> Int? {
+        guard timestamp.isFinite else { return nil }
+
+        trimSamples(olderThan: timestamp - windowDuration)
+
+        guard frameHasMeaningfulChanges(changedAreaRatio) else {
+            return nil
+        }
+
+        if let last = changedFrameTimestamps.last, timestamp <= last {
+            return nil
+        }
+
+        changedFrameTimestamps.append(timestamp)
+        trimSamples(olderThan: timestamp - windowDuration)
+
+        guard let estimate = estimateFrameRate() else {
+            return nil
+        }
+
+        estimatedFrameRate = estimate
+
+        if candidateFrameRate != estimate {
+            candidateFrameRate = estimate
+            candidateStartTime = timestamp
+            return nil
+        }
+
+        guard let candidateStartTime,
+              timestamp - candidateStartTime >= stabilityDuration,
+              estimate != currentFrameRate
+        else {
+            return nil
+        }
+
+        if let lastRecommendationTime,
+           timestamp - lastRecommendationTime < cooldownDuration {
+            return nil
+        }
+
+        currentFrameRate = estimate
+        lastRecommendationTime = timestamp
+        return estimate
+    }
+
+    static func quantizedFrameRate(for measuredFrameRate: Double) -> Int {
+        guard measuredFrameRate.isFinite else {
+            return supportedFrameRates.first ?? 30
+        }
+
+        if measuredFrameRate <= Double(supportedFrameRates[0]) {
+            return supportedFrameRates[0]
+        }
+
+        if measuredFrameRate >= Double(supportedFrameRates[supportedFrameRates.count - 1]) {
+            return supportedFrameRates[supportedFrameRates.count - 1]
+        }
+
+        return supportedFrameRates.min { first, second in
+            abs(Double(first) - measuredFrameRate) < abs(Double(second) - measuredFrameRate)
+        } ?? supportedFrameRates[0]
+    }
+
+    private func frameHasMeaningfulChanges(_ changedAreaRatio: Double?) -> Bool {
+        guard let changedAreaRatio else {
+            return true
+        }
+        return changedAreaRatio >= minimumChangedAreaRatio
+    }
+
+    private func estimateFrameRate() -> Int? {
+        guard let first = changedFrameTimestamps.first,
+              let last = changedFrameTimestamps.last,
+              changedFrameTimestamps.count >= 2
+        else {
+            return nil
+        }
+
+        let duration = last - first
+        guard duration >= 1.0 else {
+            return nil
+        }
+
+        let measuredFrameRate = Double(changedFrameTimestamps.count - 1) / duration
+        return Self.quantizedFrameRate(for: measuredFrameRate)
+    }
+
+    private mutating func trimSamples(olderThan cutoff: TimeInterval) {
+        changedFrameTimestamps.removeAll { $0 < cutoff }
+    }
+}

--- a/MetalDuck/Overlay/OverlayManager.swift
+++ b/MetalDuck/Overlay/OverlayManager.swift
@@ -201,11 +201,30 @@ class OverlayManager {
 
     // MARK: - Debug HUD
 
-    func updateDebugInfo(fps: Double, sourceFPS: Double, status: String, captureRes: CGSize, processingRes: CGSize?, mode: String) {
+    func updateDebugInfo(
+        fps: Double,
+        sourceFPS: Double,
+        effectiveCaptureFPS: Int,
+        autoCaptureFPS: Bool,
+        estimatedGameFPS: Int?,
+        status: String,
+        captureRes: CGSize,
+        processingRes: CGSize?,
+        mode: String
+    ) {
         guard showDebugOverlay, let debugTextField else { return }
 
+        let captureLine: String
+        if autoCaptureFPS {
+            let estimate = estimatedGameFPS.map { "game ~\($0)" } ?? "estimating"
+            captureLine = " Auto Capture: \(effectiveCaptureFPS) FPS (\(estimate)) "
+        } else {
+            captureLine = " Capture: \(effectiveCaptureFPS) FPS "
+        }
+
         var lines = [
-            String(format: " Capture: %.0f → Display: %.0f FPS ", sourceFPS, fps),
+            captureLine,
+            String(format: " Delivered: %.0f → Display: %.0f FPS ", sourceFPS, fps),
             " \(status) ",
             " Capture: \(Int(captureRes.width))x\(Int(captureRes.height)) ",
         ]

--- a/MetalDuck/Views/PreferencesView.swift
+++ b/MetalDuck/Views/PreferencesView.swift
@@ -83,9 +83,21 @@ struct PreferencesView: View {
                     }
                 }
 
+                Toggle("Auto Capture FPS", isOn: $captureSettings.autoFrameRateEnabled)
+
                 Stepper("Capture FPS: \(captureSettings.frameRate)",
                         value: $captureSettings.frameRate,
                         in: 30...120, step: 30)
+                    .disabled(captureSettings.autoFrameRateEnabled)
+
+                if captureSettings.autoFrameRateEnabled {
+                    Label(
+                        "Auto mode samples up to 120 FPS, then adjusts capture to the detected game rate.",
+                        systemImage: "gauge.with.dots.needle.50percent"
+                    )
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                }
 
                 HStack {
                     Button("Refresh") {
@@ -174,6 +186,15 @@ struct PreferencesView: View {
             restartCaptureIfNeeded()
         }
         .onChange(of: captureSettings.frameRate) { _, _ in
+            AppCoordinator.shared.updateCaptureSettings(captureSettings)
+            guard !captureSettings.autoFrameRateEnabled else { return }
+            restartCaptureIfNeeded()
+        }
+        .onChange(of: captureSettings.autoFrameRateEnabled) { _, newValue in
+            if newValue {
+                captureSettings.frameRate = CaptureSettings.autoFrameRateSamplingCeiling
+            }
+            AppCoordinator.shared.updateCaptureSettings(captureSettings)
             restartCaptureIfNeeded()
         }
         .sheet(isPresented: $showDiagnostics) {

--- a/MetalDuckTests/MetalDuckTests.swift
+++ b/MetalDuckTests/MetalDuckTests.swift
@@ -5,13 +5,112 @@
 //  Created by Roberto Camargo on 07/11/25.
 //
 
+import CoreMedia
 import Testing
 @testable import MetalDuck
 
 struct MetalDuckTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    @Test("Stable changed frames resolve to the matching capture rate", arguments: [30, 60, 90, 120])
+    func stableChangedFramesResolveToMatchingRate(rate: Int) {
+        let initialFrameRate = rate == 120 ? 60 : 120
+        var estimator = FrameRateEstimator(initialFrameRate: initialFrameRate)
+
+        let recommendation = feed(rate: rate, seconds: 4.0, into: &estimator)
+
+        #expect(recommendation == rate)
+        #expect(estimator.currentFrameRate == rate)
+        #expect(estimator.estimatedFrameRate == rate)
+    }
+
+    @Test func jitterAroundSixtyResolvesToSixty() {
+        var estimator = FrameRateEstimator(initialFrameRate: 120)
+        var timestamp = 0.0
+        var recommendation: Int?
+
+        for frameIndex in 0..<260 {
+            let jitter = frameIndex.isMultiple(of: 2) ? 0.0015 : -0.0015
+            timestamp += (1.0 / 60.0) + jitter
+            recommendation = estimator.observe(
+                timestamp: timestamp,
+                changedAreaRatio: 1.0
+            ) ?? recommendation
+        }
+
+        #expect(recommendation == 60)
+        #expect(estimator.currentFrameRate == 60)
+    }
+
+    @Test func staticFramesHoldLastStableRate() {
+        var estimator = FrameRateEstimator(initialFrameRate: 120)
+        _ = feed(rate: 60, seconds: 4.0, into: &estimator)
+
+        for offset in 1...300 {
+            let recommendation = estimator.observe(
+                timestamp: 4.0 + Double(offset) / 30.0,
+                changedAreaRatio: 0
+            )
+            #expect(recommendation == nil)
+        }
+
+        #expect(estimator.currentFrameRate == 60)
+    }
+
+    @Test func rateChangesRequireStabilityAndCooldown() {
+        var estimator = FrameRateEstimator(initialFrameRate: 120)
+        _ = feed(rate: 60, seconds: 4.0, into: &estimator)
+
+        let earlyRecommendation = feed(rate: 30, start: 4.0, seconds: 3.0, into: &estimator)
+        #expect(earlyRecommendation != 30)
+        #expect(estimator.currentFrameRate == 60)
+
+        let laterRecommendation = feed(rate: 30, start: 7.0, seconds: 4.0, into: &estimator)
+        #expect(laterRecommendation == 30)
+        #expect(estimator.currentFrameRate == 30)
+    }
+
+    @Test func estimatesAboveOneTwentyClampToOneTwenty() {
+        var estimator = FrameRateEstimator(initialFrameRate: 60)
+
+        let recommendation = feed(rate: 144, seconds: 4.0, into: &estimator)
+
+        #expect(recommendation == 120)
+        #expect(estimator.currentFrameRate == 120)
+    }
+
+    @Test func autoFrameRateDefaultsToManualMode() {
+        let settings = CaptureSettings()
+
+        #expect(settings.autoFrameRateEnabled == false)
+        #expect(settings.frameRate == 60)
+    }
+
+    @Test func manualFrameRateIntervalUsesConfiguredFrameRate() {
+        let interval = CaptureSettings.frameInterval(for: 60)
+
+        #expect(interval.value == 1)
+        #expect(interval.timescale == 60)
+    }
+
+    @discardableResult
+    private func feed(
+        rate: Int,
+        start: Double = 0,
+        seconds: Double,
+        into estimator: inout FrameRateEstimator,
+        changedAreaRatio: Double? = 1.0
+    ) -> Int? {
+        var recommendation: Int?
+        let frameCount = Int(Double(rate) * seconds)
+
+        for frameIndex in 0...frameCount {
+            recommendation = estimator.observe(
+                timestamp: start + Double(frameIndex) / Double(rate),
+                changedAreaRatio: changedAreaRatio
+            ) ?? recommendation
+        }
+
+        return recommendation
     }
 
 }

--- a/MetalDuckTests/Models/CaptureSettingsTests.swift
+++ b/MetalDuckTests/Models/CaptureSettingsTests.swift
@@ -1,0 +1,46 @@
+//
+//  CaptureSettingsTests.swift
+//  MetalDuckTests
+//
+//  Tests deterministic capture settings behavior without starting ScreenCaptureKit.
+//
+
+import CoreMedia
+import Testing
+@testable import MetalDuck
+
+struct CaptureSettingsTests {
+
+    @Test("Capture settings default to manual 60 FPS", .tags(.settings))
+    func defaultsToManualSixtyFPS() {
+        let settings = CaptureSettings()
+
+        #expect(settings.autoFrameRateEnabled == false, "Auto capture FPS should be opt-in.")
+        #expect(settings.frameRate == 60, "Manual capture should remain 60 FPS by default.")
+    }
+
+    @Test("Frame interval uses the configured frame rate", .tags(.settings))
+    func frameIntervalUsesConfiguredFrameRate() {
+        let interval = CaptureSettings.frameInterval(for: 60)
+
+        #expect(interval.value == 1)
+        #expect(interval.timescale == 60)
+    }
+
+    @Test(
+        "Invalid frame rates clamp to a one-second interval",
+        .tags(.settings),
+        arguments: [-120, 0, 1]
+    )
+    func invalidFrameRatesClampToOneFPS(frameRate: Int) {
+        let interval = CaptureSettings.frameInterval(for: frameRate)
+
+        #expect(interval.value == 1)
+        #expect(interval.timescale == 1)
+    }
+
+    @Test("Auto capture sampling ceiling is 120 FPS", .tags(.settings))
+    func autoSamplingCeilingIsOneTwentyFPS() {
+        #expect(CaptureSettings.autoFrameRateSamplingCeiling == 120)
+    }
+}

--- a/MetalDuckTests/Models/FrameRateEstimatorTests.swift
+++ b/MetalDuckTests/Models/FrameRateEstimatorTests.swift
@@ -1,17 +1,20 @@
 //
-//  MetalDuckTests.swift
+//  FrameRateEstimatorTests.swift
 //  MetalDuckTests
 //
-//  Created by Roberto Camargo on 07/11/25.
+//  Tests the pure timing policy used by Auto Capture FPS.
 //
 
-import CoreMedia
 import Testing
 @testable import MetalDuck
 
-struct MetalDuckTests {
+struct FrameRateEstimatorTests {
 
-    @Test("Stable changed frames resolve to the matching capture rate", arguments: [30, 60, 90, 120])
+    @Test(
+        "Stable changed frames resolve to the matching capture rate",
+        .tags(.timing),
+        arguments: [30, 60, 90, 120]
+    )
     func stableChangedFramesResolveToMatchingRate(rate: Int) {
         let initialFrameRate = rate == 120 ? 60 : 120
         var estimator = FrameRateEstimator(initialFrameRate: initialFrameRate)
@@ -23,7 +26,25 @@ struct MetalDuckTests {
         #expect(estimator.estimatedFrameRate == rate)
     }
 
-    @Test func jitterAroundSixtyResolvesToSixty() {
+    @Test(
+        "Measured frame rates quantize to supported capture rates",
+        .tags(.timing),
+        arguments: [
+            QuantizationCase(measured: 28.0, expected: 30),
+            QuantizationCase(measured: 41.0, expected: 40),
+            QuantizationCase(measured: 57.5, expected: 60),
+            QuantizationCase(measured: 76.0, expected: 72),
+            QuantizationCase(measured: 144.0, expected: 120)
+        ]
+    )
+    func measuredRatesQuantizeToSupportedRates(sample: QuantizationCase) {
+        let quantized = FrameRateEstimator.quantizedFrameRate(for: sample.measured)
+
+        #expect(quantized == sample.expected)
+    }
+
+    @Test("Jitter around 60 Hz still resolves to 60 FPS", .tags(.timing))
+    func jitterAroundSixtyResolvesToSixty() {
         var estimator = FrameRateEstimator(initialFrameRate: 120)
         var timestamp = 0.0
         var recommendation: Int?
@@ -41,7 +62,8 @@ struct MetalDuckTests {
         #expect(estimator.currentFrameRate == 60)
     }
 
-    @Test func staticFramesHoldLastStableRate() {
+    @Test("Static frames hold the last stable rate", .tags(.timing))
+    func staticFramesHoldLastStableRate() {
         var estimator = FrameRateEstimator(initialFrameRate: 120)
         _ = feed(rate: 60, seconds: 4.0, into: &estimator)
 
@@ -56,7 +78,8 @@ struct MetalDuckTests {
         #expect(estimator.currentFrameRate == 60)
     }
 
-    @Test func rateChangesRequireStabilityAndCooldown() {
+    @Test("Rate changes require stability and cooldown", .tags(.timing))
+    func rateChangesRequireStabilityAndCooldown() {
         var estimator = FrameRateEstimator(initialFrameRate: 120)
         _ = feed(rate: 60, seconds: 4.0, into: &estimator)
 
@@ -69,27 +92,13 @@ struct MetalDuckTests {
         #expect(estimator.currentFrameRate == 30)
     }
 
-    @Test func estimatesAboveOneTwentyClampToOneTwenty() {
+    @Test("Non-finite timestamps are ignored", .tags(.timing))
+    func nonFiniteTimestampsAreIgnored() {
         var estimator = FrameRateEstimator(initialFrameRate: 60)
 
-        let recommendation = feed(rate: 144, seconds: 4.0, into: &estimator)
-
-        #expect(recommendation == 120)
-        #expect(estimator.currentFrameRate == 120)
-    }
-
-    @Test func autoFrameRateDefaultsToManualMode() {
-        let settings = CaptureSettings()
-
-        #expect(settings.autoFrameRateEnabled == false)
-        #expect(settings.frameRate == 60)
-    }
-
-    @Test func manualFrameRateIntervalUsesConfiguredFrameRate() {
-        let interval = CaptureSettings.frameInterval(for: 60)
-
-        #expect(interval.value == 1)
-        #expect(interval.timescale == 60)
+        #expect(estimator.observe(timestamp: .nan, changedAreaRatio: 1.0) == nil)
+        #expect(estimator.observe(timestamp: .infinity, changedAreaRatio: 1.0) == nil)
+        #expect(estimator.currentFrameRate == 60)
     }
 
     @discardableResult
@@ -112,5 +121,13 @@ struct MetalDuckTests {
 
         return recommendation
     }
+}
 
+struct QuantizationCase: Sendable, CustomTestStringConvertible {
+    let measured: Double
+    let expected: Int
+
+    var testDescription: String {
+        "\(measured) Hz -> \(expected) FPS"
+    }
 }

--- a/MetalDuckTests/TestSupport/TestTags.swift
+++ b/MetalDuckTests/TestSupport/TestTags.swift
@@ -1,0 +1,13 @@
+//
+//  TestTags.swift
+//  MetalDuckTests
+//
+//  Shared Swift Testing tags for filtering focused test groups.
+//
+
+import Testing
+
+extension Tag {
+    @Tag static var settings: Self
+    @Tag static var timing: Self
+}


### PR DESCRIPTION
Adds opt-in Auto Capture FPS that estimates changed-frame cadence and updates ScreenCaptureKit without restarting the stream. Auto mode starts at 120 FPS and periodically probes at that ceiling so a game recovering from 30 to 60 FPS can be detected. Stability and cooldown rules limit rate changes, and static frames do not trigger probes.

The active capture rate is separate from the manual setting, so disabling auto mode restores the selected manual FPS. Preferences and the HUD distinguish the capture rate, delivered frames, and estimated source rate.

Validation: local unsigned build/test via `xcodebuild test -only-testing:MetalDuckTests` passed, including capped-stream recovery and manual-setting preservation regressions. GitHub Actions runs build and focused unit tests. Actual gameplay cadence, latency, and toggle behavior still need runtime validation.
