### PR TITLE
ci: add macOS build checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - v0.2
+  push:
+    branches:
+      - main
+      - v0.2
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: macos-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Build MetalDuck
+        run: >
+          xcodebuild build
+          -scheme MetalDuck
+          -destination 'platform=macOS'
+          -derivedDataPath "$RUNNER_TEMP/MetalDuckDerivedData"
+          CODE_SIGNING_ALLOWED=NO
+
+      - name: Run tests
+        run: >
+          xcodebuild test
+          -scheme MetalDuck
+          -destination 'platform=macOS'
+          -derivedDataPath "$RUNNER_TEMP/MetalDuckDerivedData"
+          CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,5 @@ jobs:
           -scheme MetalDuck
           -destination 'platform=macOS'
           -derivedDataPath "$RUNNER_TEMP/MetalDuckDerivedData"
+          -only-testing:MetalDuckTests
           CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions CI workflow for MetalDuck.
- Runs on pull requests and pushes for `main` and `v0.2`.
- Verifies the app with `xcodebuild build` and the `MetalDuckTests` unit target on `macos-latest`.
- Keeps generated XCTest UI tests out of the default PR gate.

## Notes

GitHub Actions did not recognize the workflow while it only existed on `v0.2`. This PR lands the workflow on the default branch so PR checks can be enabled for the repository.

## Validation

- The same `xcodebuild build` and focused `xcodebuild test -only-testing:MetalDuckTests` commands passed locally on both feature branches.
